### PR TITLE
ci: add iOS build on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
         working-directory: ios
         run: |
           xcodebuild \
-            -workspace TopikDojo.xcworkspace \
-            -scheme TopikDojo \
+            -workspace TOPIK.xcworkspace \
+            -scheme TOPIK \
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \
             -derivedDataPath build \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [main, develop]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -45,17 +47,43 @@ jobs:
       - name: Build Android APK
         run: cd android && ./gradlew assembleDebug --no-daemon
 
-  # iOS build requires macOS runner and expo prebuild
-  # Uncomment when needed:
-  # build-ios:
-  #   runs-on: macos-latest
-  #   needs: test
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: '20'
-  #         cache: 'npm'
-  #     - run: npm ci --legacy-peer-deps
-  #     - run: npx expo prebuild --platform ios --non-interactive
-  #     - run: cd ios && xcodebuild -workspace TopikDojo.xcworkspace -scheme TopikDojo -configuration Debug -destination 'generic/platform=iOS Simulator' build
+  build-ios:
+    runs-on: [self-hosted, macOS, ARM64]
+    needs: test
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Add Homebrew to PATH
+        run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Generate native project (CNG)
+        run: npx expo prebuild --platform ios --non-interactive
+
+      - name: Install CocoaPods dependencies
+        working-directory: ios
+        run: pod install
+
+      - name: Build iOS (Simulator)
+        working-directory: ios
+        run: |
+          xcodebuild \
+            -workspace TopikDojo.xcworkspace \
+            -scheme TopikDojo \
+            -configuration Debug \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Clean up generated native project
+        if: always()
+        run: rm -rf ios


### PR DESCRIPTION
## Summary

- セルフホステッドランナー（watari Mac mini M4）を使った iOS ビルドジョブを追加
- トリガーを `pull_request` のみに変更（main マージ時の不要な再実行を排除）
- 未使用の `develop` ブランチをトリガーから削除
- 同一 PR への連続 push 時に古い実行をキャンセルする `concurrency` を追加

## build-ios ジョブの流れ

1. `actions/setup-node` で Node 20 をセットアップ（ランナーのグローバル環境に影響なし）
2. Homebrew の PATH を追加（`pod` コマンド用）
3. `npm ci --legacy-peer-deps`
4. `npx expo prebuild --platform ios` で CNG
5. `pod install`
6. `xcodebuild` で Simulator 向け Debug ビルド（コード署名なし）
7. ビルド後に `ios/` をクリーンアップ

## 前提条件（watari 側で完了済み）

- Xcode 26 インストール済み
- CocoaPods インストール済み（`brew install cocoapods`）
- GitHub Actions ランナーをサービスとして登録・起動済み

Made with [Cursor](https://cursor.com)